### PR TITLE
Fix UTF-8 multi-byte character handling in injection range calculation

### DIFF
--- a/crates/cli/src/api/injections.rs
+++ b/crates/cli/src/api/injections.rs
@@ -113,13 +113,7 @@ fn point_to_byte(source: &str, point: Point) -> Option<usize> {
 
   for (current_row, line) in source.split_inclusive('\n').enumerate() {
     if current_row == point.row {
-      let mut col_byte = 0;
-      for (i, ch) in line.chars().enumerate() {
-        if i == point.column {
-          break;
-        }
-        col_byte += ch.len_utf8();
-      }
+      let col_byte = point.column.min(line.len());
       return Some(byte_index + col_byte);
     }
 

--- a/crates/cli/tests/fixtures/tests/utf8_docstring/input.clj
+++ b/crates/cli/tests/fixtures/tests/utf8_docstring/input.clj
@@ -1,0 +1,19 @@
+(defn somefunc
+   "2-byte UTF-8: Cyrillic (кириллица) and accents (café, señor, über)"
+   [ ]
+   (print "hello"))
+
+(defn another-func
+   "3-byte UTF-8: Chinese (中文), Japanese (日本語), Korean (한글)"
+     []
+       nil)
+
+(defn emoji-func
+   "4-byte UTF-8: Emojis 🚀🎉👨‍💻 and symbols 𝕳𝖊𝖑𝖑𝖔"
+ []
+   :ok)
+
+(defn mixed-func
+   "Mixed: Привет мир! 你好世界! 🌍 γειά σου κόσμε"
+     []
+ true)

--- a/crates/cli/tests/fixtures/tests/utf8_docstring/output.clj
+++ b/crates/cli/tests/fixtures/tests/utf8_docstring/output.clj
@@ -1,0 +1,19 @@
+(defn somefunc
+  "2-byte UTF-8: Cyrillic (кириллица) and accents (café, señor, über)"
+  []
+  (print "hello"))
+
+(defn another-func
+  "3-byte UTF-8: Chinese (中文), Japanese (日本語), Korean (한글)"
+  []
+  nil)
+
+(defn emoji-func
+  "4-byte UTF-8: Emojis 🚀🎉👨‍💻 and symbols 𝕳𝖊𝖑𝖑𝖔"
+  []
+  :ok)
+
+(defn mixed-func
+  "Mixed: Привет мир! 你好世界! 🌍 γειά σου κόσμε"
+  []
+  true)

--- a/crates/cli/tests/format_command_test.rs
+++ b/crates/cli/tests/format_command_test.rs
@@ -316,3 +316,36 @@ fn markdown_with_html() -> Result<()> {
 
   Ok(())
 }
+
+#[test]
+fn utf8_docstring() -> Result<()> {
+  let grammars = common::grammars()?;
+  let formatters = common::formatters();
+  let languages = common::languages();
+  let wasm_formatter = WasmFormatter::new("cache".into())?;
+
+  let source = common::load_file("utf8_docstring/input.clj");
+
+  let result = format::format(
+    source.as_bytes(),
+    &FormatOpts {
+      printwidth: 80,
+      language: "clojure",
+    },
+    true,
+    true,
+    &FormatContext {
+      grammars: &grammars,
+      languages: &languages,
+      formatters: &formatters,
+      wasm_formatter: &wasm_formatter,
+    },
+  )
+  .unwrap();
+
+  let expected = common::load_file("utf8_docstring/output.clj");
+
+  assert_eq!(String::from_utf8(result).unwrap(), expected);
+
+  Ok(())
+}


### PR DESCRIPTION
Bug formatting clojure code (in my case) when docstring contains multibyte characters. 

Steps to reproduce:
```
echo '(defn somefunc
       "here is a docsring (emoji 😮‍💨) lol"
       []
       (print "hello"))' | pruner format --lang clojure
```
The result will be broken code:
```
(defn somefunc
  "here is a docsring (emoji 😮‍💨) lol\"
  []
  (print "hello"))
```
It escaped closing quote because of incorrect offset calculation.

This fixes issue when `point_to_byte` wasn't properly calculating character offset for multibyte encodings. Treesitter's Point.column (byte offset) was treated like character index which isn't.


https://tree-sitter.github.io/tree-sitter/using-parsers/2-basic-parsing.html#syntax-nodes

